### PR TITLE
Separate Solution objects for each condition instead of a global Solution object

### DIFF
--- a/rh/simulations.py
+++ b/rh/simulations.py
@@ -39,7 +39,7 @@ import seaborn as sns
 import os
 import multiprocessing
 from functools import partial
-
+import threading
 # unit conversion factors to SI
 mm = 0.001
 cm = 0.01
@@ -87,7 +87,7 @@ def setup_ct_solution(path_to_cti):
     surf = ct.Interface(path_to_cti, 'surface1', [gas])
 
     print("This mechanism contains {} gas reactions and {} surface reactions".format(gas.n_reactions, surf.n_reactions))
-
+    print(f"Thread ID from threading{threading.get_ident()}")
     i_ar = gas.species_index('Ar')
 
     
@@ -255,6 +255,7 @@ def monolith_simulation(path_to_cti, temp, mol_in, verbose=False, sens=False):
     """
     sols_dict = setup_ct_solution(path_to_cti)
     gas, surf, i_ar, n_surf_reactions= sols_dict['gas'], sols_dict['surf'], sols_dict['i_ar'],sols_dict['n_surf_reactions']
+    print(f"Running monolith simulation with CH4 and O2 concs {mol_in[0], mol_in[1]} on thread {threading.get_ident()}")
     ch4, o2, ar = mol_in
     ratio = ch4 / (2 * o2)
 
@@ -378,6 +379,7 @@ def monolith_simulation(path_to_cti, temp, mol_in, verbose=False, sens=False):
     gas_names = np.array(gas_names)
     surf_names = np.array(surf_names)
     data_out = gas_out, surf_out, gas_names, surf_names, dist_array, T_array, i_ar, n_surf_reactions
+    print(f"Finished monolith simulation for CH4 and O2 concs {mol_in[0], mol_in[1]} on thread {threading.get_ident()}")
     return data_out
 
 def run_one_simulation(path_to_cti, ratio):


### PR DESCRIPTION
Multiprocessing fix by Krishna.

> reran your simulations script with Solution objects for each condition instead of the global Solution obj and I think they look different than the ones you posted a week ago
> Running Cantera simulations in parallel using multiprocessing  on a single `Solution` obj is not a good practice (I learned this last week), cause Solution object will be updating throughout the simulation and it’s always nice to have to separate Solution obj for each condition.  I modified the simlations.py script in cpox repo and ran it on discovery and these are the plots I got from that run